### PR TITLE
Fixed a problem with the "selected selector" not working in IE8.

### DIFF
--- a/jqDropDown.jquery.js
+++ b/jqDropDown.jquery.js
@@ -45,7 +45,7 @@ http://www.opensource.org/licenses/mit-license.php
 		if ( defaultOption && defaultOption !== '' ) {
 			selectedLabel = defaultOption;
 		} else {
-			selectedLabel = $dropdown.find('option[selected]').text() || $dropdown.find('option:eq(0)').text();
+			selectedLabel = $dropdown.find('option[selected="selected"]').text() || $dropdown.find('option:eq(0)').text();
 		}
 		
 		// Append the toggle hyperlink to the new DropDown container


### PR DESCRIPTION
$dropdown.find('option[selected]').text() returns an empty string in IE8, preventing the correct selected item from being selected in the custom dropdown, only seems to happen in IE8.
